### PR TITLE
Fix: dynamic client read buffer to support payloads >8KB (issue: #3)

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <memory>
 #include <fcntl.h>
+#include <vector>
 
 
 class RedisServer
@@ -17,10 +18,12 @@ private:
     Arena arena;
     std::unordered_map<std::string, std::string> store;
     std::unordered_map<int, std::unique_ptr<Socket>> clients;
+    static constexpr size_t INITIAL_BUF = 8 * 1024;
+    static constexpr size_t MAX_BUF     = 64 * 1024 * 1024;
     
     struct ClientBuffer 
     {
-        char data[8192];
+        std::vector<char> data;
         size_t len = 0;
         std::string write_buf;
         size_t write_pos = 0;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -75,7 +75,10 @@ void RedisServer::handle_new_connection()
     clients[raw_client_fd] = std::make_unique<Socket>(raw_client_fd);
     
     // Initialize buffer
-    client_buffers[raw_client_fd] = ClientBuffer{};
+    ClientBuffer cb;
+    cb.data.resize(INITIAL_BUF);
+    client_buffers[raw_client_fd] = std::move(cb);
+
     
     std::cout << "New client connected: " << raw_client_fd << std::endl;
 }
@@ -85,17 +88,30 @@ void RedisServer::handle_client_data(int fd)
     ClientBuffer& buf = client_buffers[fd];
 
     // Drain the socket so edge-triggered epoll does not leave unread bytes queued.
-    while (buf.len < sizeof(buf.data))
+    while (true) 
     {
-        ssize_t bytes = read(fd, buf.data + buf.len, sizeof(buf.data) - buf.len);
+        if (buf.len == buf.data.size()) 
+        {
+            if (buf.data.size() >= MAX_BUF) 
+            {
+                // Pathological client — close instead of OOMing
+                std::cout << "Client exceeded MAX_BUF, closing: " << fd << std::endl;
+                epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+                clients.erase(fd);
+                client_buffers.erase(fd);
+                return;
+            }
+            buf.data.resize(std::min(buf.data.size() * 2, MAX_BUF));
+        }
 
-        if (bytes > 0)
+        ssize_t bytes = read(fd, buf.data.data() + buf.len, buf.data.size() - buf.len);
+
+        if (bytes > 0) 
         {
             buf.len += static_cast<size_t>(bytes);
             continue;
         }
-
-        if (bytes == 0)
+        if (bytes == 0) 
         {
             std::cout << "Client disconnected: " << fd << std::endl;
             epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
@@ -103,26 +119,18 @@ void RedisServer::handle_client_data(int fd)
             client_buffers.erase(fd);
             return;
         }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+        if (errno == EINTR) continue;
 
-        if (errno == EAGAIN || errno == EWOULDBLOCK)
-        {
-            break;
-        }
-
-        if (errno == EINTR)
-        {
-            continue;
-        }
-
-        std::cout << "Client disconnected: " << fd << std::endl;
+        std::cout << "Client read error: " << fd << std::endl;
         epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
         clients.erase(fd);
         client_buffers.erase(fd);
         return;
     }
-    
+
     // Process all complete commands in buffer
-    RESPParser parser(buf.data, buf.len);
+    RESPParser parser(buf.data.data(), buf.len);
     std::vector<std::string_view> tokens;
 
     std::string response_buffer; 
@@ -136,8 +144,14 @@ void RedisServer::handle_client_data(int fd)
         {
             if (parser.pos > 0) 
             {
-                memmove(buf.data, buf.data + parser.pos, buf.len - parser.pos);
+                memmove(buf.data.data(), buf.data.data() + parser.pos, buf.len - parser.pos);
                 buf.len -= parser.pos;
+
+                if (buf.data.size() > INITIAL_BUF && buf.len <= INITIAL_BUF / 2) {
+                    buf.data.resize(INITIAL_BUF);
+                    buf.data.shrink_to_fit();
+                }
+
             }
             break;
         }


### PR DESCRIPTION
## Problem
ClientBuffer used a fixed `char data[8192]`. Any single command exceeding
~8 KB wedged the connection: the buffer filled before a complete command
arrived, the parser couldn't make progress, and no further reads happened.

Repro from issue #3:
    redis-cli SET foo "$(head -c 9000 /dev/urandom | base64)"

Fixes #3.

## Fix
- ClientBuffer.data → std::vector<char>, starts at 8 KB, doubles on demand
- Hard cap at MAX_BUF (64 MB) — pathological clients are closed, not OOM'd
- Shrinks back to 8 KB once usage drops below INITIAL_BUF / 2

## Verification
- 9 KB SET + GET round-trips correctly (was: connection drop)
- 1 MB SET + GET round-trips correctly
- redis-benchmark -t set,get unchanged on small payloads
