### PR TITLE
Fix: validate RESP parser inputs to reject malformed commands (issue:…

### DIFF
--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -9,7 +9,11 @@ struct RESPParser
     const char* data;
     size_t len;
     size_t pos;
-    
+    bool protocol_error = false;
+
+    static constexpr int MAX_ARRAY_SIZE = 1024 * 1024;
+    static constexpr int MAX_BULK_LEN = 64 * 1024 * 1024;
+
     RESPParser(const char* d, size_t l) : data(d), len(l), pos(0) {}
     
     // Fast integer parsing
@@ -18,7 +22,8 @@ struct RESPParser
         int result = 0;
         bool negative = false;
         
-        if (p < len && data[p] == '-') {
+        if (p < len && data[p] == '-') 
+        {
             negative = true;
             p++;
         }
@@ -31,50 +36,96 @@ struct RESPParser
         
         return negative ? -result : result;
     }
-    
-    // Returns number of bytes consumed, or 0 if incomplete
-    size_t try_parse_command(std::vector<std::string_view>& tokens) 
+
+        bool parse_int_crlf(size_t& p, int& out)
+    {
+        size_t start = p;
+        bool negative = false;
+
+        if (p < len && data[p] == '-') { negative = true; p++; }
+
+        size_t digits_start = p;
+        long long result = 0;
+        while (p < len && data[p] >= '0' && data[p] <= '9') 
+        {
+            result = result * 10 + (data[p] - '0');
+            if (result > INT32_MAX) { protocol_error = true; p = start; return false; }
+            p++;
+        }
+
+        if (p == digits_start) 
+        {
+            if (p >= len) { p = start; return false; }   // incomplete
+            protocol_error = true;                       // non-digit where digit expected
+            p = start;
+            return false;
+        }
+
+        if (p + 1 >= len) { p = start; return false; }   // incomplete (need \r\n)
+        if (data[p] != '\r' || data[p + 1] != '\n') 
+        {
+            protocol_error = true;
+            p = start;
+            return false;
+        }
+        p += 2;
+
+        out = negative ? -static_cast<int>(result) : static_cast<int>(result);
+        return true;
+    }
+
+    size_t try_parse_command(std::vector<std::string_view>& tokens)
     {
         tokens.clear();
         size_t start = pos;
-        
+
         if (pos >= len) return 0;
-        if (data[pos] != '*') return 0;
+        if (data[pos] != '*') { protocol_error = true; return 0; }
         pos++;
-        
-        int array_size = parse_int(pos);
-        if (pos + 1 >= len || data[pos] != '\r' || data[pos + 1] != '\n') 
-        { 
-            pos = start; tokens.clear(); return 0; 
+
+        int array_size;
+        if (!parse_int_crlf(pos, array_size)) { pos = start; return 0; }
+
+        if (array_size < 0 || array_size > MAX_ARRAY_SIZE) 
+        {
+            protocol_error = true;
+            pos = start;
+            return 0;
         }
-        pos += 2;
-        
+
         for (int i = 0; i < array_size; i++) 
         {
-            if (pos >= len || data[pos] != '$') 
-            { 
-                pos = start; tokens.clear(); return 0; 
+            if (pos >= len) { pos = start; tokens.clear(); return 0; }
+            if (data[pos] != '$') {
+                protocol_error = true;
+                pos = start; tokens.clear();
+                return 0;
             }
             pos++;
-            
-            int str_len = parse_int(pos);
-            if (pos + 1 >= len || data[pos] != '\r' || data[pos + 1] != '\n') 
-            { 
-                pos = start; tokens.clear(); return 0; 
+
+            int str_len;
+            if (!parse_int_crlf(pos, str_len)) 
+            {
+                pos = start; tokens.clear();
+                return 0;
             }
-            pos += 2;
-            
-            if (pos + str_len + 2 > len) 
-            { 
-                pos = start; tokens.clear(); return 0; 
+
+            if (str_len < 0 || str_len > MAX_BULK_LEN) 
+            {
+                protocol_error = true;
+                pos = start; tokens.clear();
+                return 0;
             }
-            
-            // ZERO COPY MAGIC HERE:
-            // Instead of making a string, we make a view.
-            tokens.emplace_back(data + pos, str_len);
-            
-            pos += str_len + 2; 
+
+            if (pos + static_cast<size_t>(str_len) + 2 > len) 
+            {
+                pos = start; tokens.clear();
+                return 0;   // incomplete
+            }
+
+            tokens.emplace_back(data + pos, static_cast<size_t>(str_len));
+            pos += static_cast<size_t>(str_len) + 2;
         }
-        return pos - start; 
+        return pos - start;
     }
 };

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -140,9 +140,17 @@ void RedisServer::handle_client_data(int fd)
     {
         size_t consumed = parser.try_parse_command(tokens);
         
-        if (consumed == 0) 
+        if (consumed == 0)
         {
-            if (parser.pos > 0) 
+            if (parser.protocol_error)
+            {
+                std::cout << "Protocol error, closing client: " << fd << std::endl;
+                epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+                clients.erase(fd);
+                client_buffers.erase(fd);
+                return;
+            }
+            if (parser.pos > 0)
             {
                 memmove(buf.data.data(), buf.data.data() + parser.pos, buf.len - parser.pos);
                 buf.len -= parser.pos;
@@ -151,10 +159,10 @@ void RedisServer::handle_client_data(int fd)
                     buf.data.resize(INITIAL_BUF);
                     buf.data.shrink_to_fit();
                 }
-
             }
             break;
         }
+
         
         if (!tokens.empty())
         {
@@ -285,7 +293,7 @@ void RedisServer::arm_epollout(int fd, bool on)
     ClientBuffer& buf = client_buffers[fd];
     if (buf.epollout_armed == on) return;
     struct epoll_event ev{};
-    ev.events = EPOLLIN | EPOLLET | (on ? EPOLLOUT : 0);
+    ev.events = EPOLLIN | EPOLLET | (on ? EPOLLOUT : 0u);
     ev.data.fd = fd;
     epoll_ctl(epoll_fd.get(), EPOLL_CTL_MOD, fd, &ev);
     buf.epollout_armed = on;


### PR DESCRIPTION
## Problem
RESPParser had multiple validation gaps (issue #4):
1. parse_int silently returned 0 on non-numeric input — `*abc\r\n` was accepted as an empty command
2. No cap on array_size — `*99999999\r\n` forced large loops
3. Negative bulk length (`$-1\r\n`) caused signed/unsigned mixing → potential OOB read
4. No `str_len >= 0` check before use

## Fix
- `parse_int_crlf` returns success/fail and distinguishes incomplete vs malformed
- New `protocol_error` flag — server closes the connection when set instead of silently waiting for more bytes
- `array_size` capped at 1M, `str_len` capped at 64 MB (matches MAX_BUF)
- Negative lengths rejected for both arrays and bulks

## Verification
Server log when sending malformed RESP via `ncat`:
    Protocol error, closing client: 5    (×5 — one per bad input)

Inputs covered:
- `*abc\r\n`               (was: silently accepted as empty)
- `*1\r\n$-1\r\n`          (was: OOB read risk)
- `*99999999\r\n`          (was: large-loop DoS)
- `*1\r\n$99999999999\r\n` (was: unbounded read attempt)
- `JUNK\r\n`               (no leading `*`)

Sanity: PING returns `+PONG`, SET/GET unaffected.

Fixes #4.