### PR TITLE
Perf: increase epoll batch size from 16 to 1024 (issue :#7)

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -240,11 +240,12 @@ void RedisServer::handle_client_data(int fd)
 
 void RedisServer::run()
 {
-    struct epoll_event events[16];
+    static constexpr int MAX_EPOLL_EVENTS = 1024;
+    struct epoll_event events[MAX_EPOLL_EVENTS];
 
     while (running)
     {
-        int nfds = epoll_wait(epoll_fd.get(), events, 16, -1);
+        int nfds = epoll_wait(epoll_fd.get(), events, MAX_EPOLL_EVENTS, -1);
         if (nfds == -1) {
             if (errno == EINTR) continue;
             break;


### PR DESCRIPTION
## Problem
`run()` used a 16-event buffer for `epoll_wait`. With 500 concurrent
clients the kernel readiness queue routinely held more events than that,
forcing extra `epoll_wait` syscalls per round-trip.

## Fix
Bumped the per-call batch to 1024 (named `MAX_EPOLL_EVENTS`). Matches
the default batch size used by Redis / nginx. ~12 KB on the stack — no
heap allocation, no startup cost.

## Verification
Workload: redis-benchmark, -c 500, 3-run median throughput, plus strace
for syscall accounting (-n 100000 -c 500 SET).

| Metric                | Before (16) | After (1024) |
|-----------------------|-------------|--------------|
| epoll_wait calls      | 6,664       | 613   (−91%) |
| epoll_wait CPU (ms)   | 38.3        | 16.1  (−58%) |
| Throughput SET (med)  | ~79.7k r/s  | ~80.9k r/s   |
| Throughput GET (med)  | ~80.5k r/s  | ~81.4k r/s   |

Throughput delta at this concurrency is within noise; the syscall
reduction is the structural win and frees CPU for higher loads.

No correctness change. SET/GET sanity, malformed-RESP rejection, and
graceful shutdown all unaffected.

Fixes #7.