### PR TITLE
Refactor: merge clients/client_buffers into a single fd-keyed map (is…

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -16,14 +16,15 @@ private:
     Socket server_socket;
     Socket epoll_fd;
     Socket signal_fd;
-    bool running = true;
+    bool   running = true;
     std::unordered_map<std::string, std::string> store;
-    std::unordered_map<int, std::unique_ptr<Socket>> clients;
+
     static constexpr size_t INITIAL_BUF = 8 * 1024;
     static constexpr size_t MAX_BUF     = 64 * 1024 * 1024;
-    
-    struct ClientBuffer 
+
+    struct ClientBuffer
     {
+        Socket socket;                  // owns the client fd
         std::vector<char> data;
         size_t len = 0;
         std::string write_buf;
@@ -31,7 +32,7 @@ private:
         bool epollout_armed = false;
     };
 
-    std::unordered_map<int, ClientBuffer> client_buffers;
+    std::unordered_map<int, ClientBuffer> clients;
 
     //  Set Non-Blocking
     void set_nonblocking(int fd)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -98,12 +98,11 @@ void RedisServer::handle_new_connection()
     epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, raw_client_fd, &ev);
     
     // Store in RAII wrapper
-    clients[raw_client_fd] = std::make_unique<Socket>(raw_client_fd);
-    
-    // Initialize buffer
     ClientBuffer cb;
+    cb.socket = Socket(raw_client_fd);
     cb.data.resize(INITIAL_BUF);
-    client_buffers[raw_client_fd] = std::move(cb);
+    clients[raw_client_fd] = std::move(cb);
+
 
     
     std::cout << "New client connected: " << raw_client_fd << std::endl;
@@ -111,7 +110,7 @@ void RedisServer::handle_new_connection()
 
 void RedisServer::handle_client_data(int fd)
 {
-    ClientBuffer& buf = client_buffers[fd];
+    ClientBuffer& buf = clients[fd];
 
     // Drain the socket so edge-triggered epoll does not leave unread bytes queued.
     while (true) 
@@ -124,7 +123,6 @@ void RedisServer::handle_client_data(int fd)
                 std::cout << "Client exceeded MAX_BUF, closing: " << fd << std::endl;
                 epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
                 clients.erase(fd);
-                client_buffers.erase(fd);
                 return;
             }
             buf.data.resize(std::min(buf.data.size() * 2, MAX_BUF));
@@ -142,7 +140,6 @@ void RedisServer::handle_client_data(int fd)
             std::cout << "Client disconnected: " << fd << std::endl;
             epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
             clients.erase(fd);
-            client_buffers.erase(fd);
             return;
         }
         if (errno == EAGAIN || errno == EWOULDBLOCK) break;
@@ -151,7 +148,6 @@ void RedisServer::handle_client_data(int fd)
         std::cout << "Client read error: " << fd << std::endl;
         epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
         clients.erase(fd);
-        client_buffers.erase(fd);
         return;
     }
 
@@ -173,7 +169,6 @@ void RedisServer::handle_client_data(int fd)
                 std::cout << "Protocol error, closing client: " << fd << std::endl;
                 epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
                 clients.erase(fd);
-                client_buffers.erase(fd);
                 return;
             }
             if (parser.pos > 0)
@@ -275,7 +270,7 @@ void RedisServer::run()
     }
 
     // Best-effort flush of pending writes before sockets close
-    for (auto& kv : client_buffers) {
+    for (auto& kv : clients) {
         try_flush(kv.first);
     }
 
@@ -285,8 +280,8 @@ void RedisServer::run()
 
 void RedisServer::try_flush(int fd)
 {
-    auto it = client_buffers.find(fd);
-    if (it == client_buffers.end()) return;
+    auto it = clients.find(fd);
+    if (it == clients.end()) return;
     ClientBuffer& buf = it->second;
 
     while (buf.write_pos < buf.write_buf.size())
@@ -311,7 +306,6 @@ void RedisServer::try_flush(int fd)
 
         epoll_ctl( epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
         clients.erase(fd);
-        client_buffers.erase(fd);
         return;
     }
     //fully drained - reclaim memory and stop watching EPOLLOUT
@@ -322,7 +316,7 @@ void RedisServer::try_flush(int fd)
 
 void RedisServer::arm_epollout(int fd, bool on)
 {
-    ClientBuffer& buf = client_buffers[fd];
+    ClientBuffer& buf = clients[fd];
     if (buf.epollout_armed == on) return;
     struct epoll_event ev{};
     ev.events = EPOLLIN | EPOLLET | (on ? EPOLLOUT : 0u);


### PR DESCRIPTION
## Problem
Two parallel maps keyed by the same fd:
- unordered_map<int, unique_ptr<Socket>>  clients
- unordered_map<int, ClientBuffer>        client_buffers

Every request did two independent lookups; every disconnect path had to
erase from both maps and stay in sync — a footgun for future bugs.

## Fix
- Move `Socket` into `ClientBuffer` (Socket is already move-only, RAII)
- Single `unordered_map<int, ClientBuffer> clients`
- Erase paths now touch one map; fd close is guaranteed by the
  Socket destructor inside ClientBuffer

## Verification
- SET/GET round-trip
- redis-benchmark -t set,get -n 100k -c 50 unchanged
- Malformed RESP still rejected
- SIGTERM still produces clean shutdown

Fixes: Issue #8