### PR TITLE
Fix/issue 15 check syscall returns

### DIFF
--- a/include/server.hpp
+++ b/include/server.hpp
@@ -35,10 +35,11 @@ private:
     std::unordered_map<int, ClientBuffer> clients;
 
     //  Set Non-Blocking
-    void set_nonblocking(int fd)
+    bool set_nonblocking(int fd)
     {
         int flags = fcntl(fd, F_GETFL, 0);
-        fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+        if (flags == -1) return false;
+        return fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1;
     }
 
     void handle_new_connection();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -46,15 +46,25 @@ RedisServer::RedisServer(int port)
     address.sin_port = htons(port);
 
     int opt = 1;
-    setsockopt(server_socket.get(), SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    if (setsockopt(server_socket.get(), SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
+    {
+        throw std::runtime_error("setsockopt(SO_REUSEADDR) failed");
+    }
+
 
     if (bind(server_socket.get(), (struct sockaddr*)&address, sizeof(address)) == -1)
     {
         throw std::runtime_error("Bind failed");
     }
 
-    listen(server_socket.get(), SOMAXCONN);
-    set_nonblocking(server_socket.get());
+    if (listen(server_socket.get(), SOMAXCONN) == -1)
+    {
+        throw std::runtime_error("listen failed");
+    }
+    if (!set_nonblocking(server_socket.get()))
+    {
+        throw std::runtime_error("set_nonblocking on listening socket failed");
+    }
 
     // 3. Create Epoll
     int raw_epoll = epoll_create1(0);
@@ -68,13 +78,19 @@ RedisServer::RedisServer(int port)
     struct epoll_event ev{};
     ev.events = EPOLLIN;
     ev.data.fd = server_socket.get();
-    epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, server_socket.get(), &ev);
+    if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, server_socket.get(), &ev) == -1)
+    {
+        throw std::runtime_error("epoll_ctl ADD listening socket failed");
+    }
 
     // 5. Add Signalfd to Epoll
     struct epoll_event sig_ev{};
     sig_ev.events = EPOLLIN;
     sig_ev.data.fd = signal_fd.get();
-    epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, signal_fd.get(), &sig_ev);
+    if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, signal_fd.get(), &sig_ev) == -1)
+    {
+        throw std::runtime_error("epoll_ctl ADD signalfd failed");
+    }
 
     std::cout << "Server (RAII) listening on port " << port << std::endl;
 }
@@ -90,19 +106,28 @@ void RedisServer::handle_new_connection()
     if (raw_client_fd == -1)
         return;
 
-    set_nonblocking(raw_client_fd);
-    
-    // Add to epoll
+    if (!set_nonblocking(raw_client_fd))
+    {
+        std::cout << "set_nonblocking failed for client " << raw_client_fd << ", closing\n";
+        close(raw_client_fd);
+        return;
+    }
+
     struct epoll_event ev{};
     ev.events = EPOLLIN | EPOLLET;
     ev.data.fd = raw_client_fd;
-    epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, raw_client_fd, &ev);
-    
-    // Store in RAII wrapper
+    if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, raw_client_fd, &ev) == -1)
+    {
+        std::cout << "epoll_ctl ADD failed for client " << raw_client_fd << ", closing\n";
+        close(raw_client_fd);
+        return;
+    }
+
     ClientBuffer cb;
     cb.socket = Socket(raw_client_fd);
     cb.data.resize(INITIAL_BUF);
     clients[raw_client_fd] = std::move(cb);
+
 
 
     
@@ -122,7 +147,12 @@ void RedisServer::handle_client_data(int fd)
             {
                 // Pathological client — close instead of OOMing
                 std::cout << "Client exceeded MAX_BUF, closing: " << fd << std::endl;
-                epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+                if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr) == -1
+                    && errno != ENOENT && errno != EBADF)
+                {
+                    std::cout << "epoll_ctl DEL warning for fd " << fd
+                              << ": errno=" << errno << "\n";
+                }
                 clients.erase(fd);
                 return;
             }
@@ -139,7 +169,12 @@ void RedisServer::handle_client_data(int fd)
         if (bytes == 0) 
         {
             std::cout << "Client disconnected: " << fd << std::endl;
-            epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+            if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr) == -1
+                && errno != ENOENT && errno != EBADF)
+            {
+                std::cout << "epoll_ctl DEL warning for fd " << fd
+                          << ": errno=" << errno << "\n";
+            }
             clients.erase(fd);
             return;
         }
@@ -147,7 +182,12 @@ void RedisServer::handle_client_data(int fd)
         if (errno == EINTR) continue;
 
         std::cout << "Client read error: " << fd << std::endl;
-        epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+        if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr) == -1
+            && errno != ENOENT && errno != EBADF)
+        {
+            std::cout << "epoll_ctl DEL warning for fd " << fd
+                      << ": errno=" << errno << "\n";
+        }
         clients.erase(fd);
         return;
     }
@@ -165,7 +205,12 @@ void RedisServer::handle_client_data(int fd)
             if (parser.protocol_error)
             {
                 std::cout << "Protocol error, closing client: " << fd << std::endl;
-                epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+                if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr) == -1
+                    && errno != ENOENT && errno != EBADF)
+                {
+                    std::cout << "epoll_ctl DEL warning for fd " << fd
+                              << ": errno=" << errno << "\n";
+                }
                 clients.erase(fd);
                 return;
             }
@@ -307,7 +352,12 @@ void RedisServer::try_flush(int fd)
         }
         // real error - close connection
 
-        epoll_ctl( epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr);
+        if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_DEL, fd, nullptr) == -1
+            && errno != ENOENT && errno != EBADF)
+        {
+            std::cout << "epoll_ctl DEL warning for fd " << fd
+                      << ": errno=" << errno << "\n";
+        }
         clients.erase(fd);
         return;
     }
@@ -324,8 +374,14 @@ void RedisServer::arm_epollout(int fd, bool on)
     struct epoll_event ev{};
     ev.events = EPOLLIN | EPOLLET | (on ? EPOLLOUT : 0u);
     ev.data.fd = fd;
-    epoll_ctl(epoll_fd.get(), EPOLL_CTL_MOD, fd, &ev);
+    if (epoll_ctl(epoll_fd.get(), EPOLL_CTL_MOD, fd, &ev) == -1)
+    {
+        std::cout << "epoll_ctl MOD failed for fd " << fd << ", closing client\n";
+        clients.erase(fd);   // Socket destructor closes the fd
+        return;
+    }
     buf.epollout_armed = on;
+
 }
 
 void RedisServer::handle_client_writable(int fd)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -10,6 +10,7 @@
 #include <cerrno>
 #include <csignal>
 #include <sys/signalfd.h>
+#include <charconv>
 
 RedisServer::RedisServer(int port)
 {
@@ -154,9 +155,6 @@ void RedisServer::handle_client_data(int fd)
     // Process all complete commands in buffer
     RESPParser parser(buf.data.data(), buf.len);
     std::vector<std::string_view> tokens;
-
-    std::string response_buffer; 
-    response_buffer.reserve(4096);
     
     while (true)
     {
@@ -191,12 +189,12 @@ void RedisServer::handle_client_data(int fd)
             
             if (cmd == "PING") 
             {
-                response_buffer.append("+PONG\r\n");
+                buf.write_buf.append("+PONG\r\n");
             }
             else if (cmd == "SET" && tokens.size() >= 3)
             {
                 store[std::string(tokens[1])] = std::string(tokens[2]);
-                response_buffer.append("+OK\r\n");
+                buf.write_buf.append("+OK\r\n");
             }
 
 
@@ -210,26 +208,31 @@ void RedisServer::handle_client_data(int fd)
 
                 if (it != store.end()) {
                     std::string_view val = it->second;
-                    response_buffer.append("$").append(std::to_string(val.length())).append("\r\n");
-                    response_buffer.append(val); // Efficient append
-                    response_buffer.append("\r\n");
+                    char numbuf[24];
+                    auto [end, ec] = std::to_chars(numbuf, numbuf + sizeof(numbuf), val.length());
+                    buf.write_buf.append("$");
+                    buf.write_buf.append(numbuf, end - numbuf);
+                    buf.write_buf.append("\r\n");
+                    buf.write_buf.append(val);
+                    buf.write_buf.append("\r\n");
                 } else {
-                    response_buffer.append("$-1\r\n");
+                    buf.write_buf.append("$-1\r\n");
                 }
+
             }
             else 
             {
-                response_buffer.append("-ERR unknown command\r\n");
+                buf.write_buf.append("-ERR unknown command\r\n");
             }
         }
     }
-            
+    
     // Send everything in ONE System Call
-    if (!response_buffer.empty()) 
+    if (buf.write_pos < buf.write_buf.size())
     {
-        buf.write_buf.append(response_buffer);
         try_flush(fd);
     }
+
 }
 
 


### PR DESCRIPTION
## Problem
Several syscalls (setsockopt, listen, epoll_ctl, fcntl in set_nonblocking)
had their return values discarded. A failure would silently produce a
server that's running but broken — accepting connections that get no
events, or unable to bind on restart, with no log.

## Fix
Failure-domain analysis applied to each call:
- **Startup-fatal** (setsockopt, listen, set_nonblocking on listener,
  EPOLL_CTL_ADD for listener/signalfd): throw std::runtime_error
  with a specific message — fail fast rather than run broken.
- **Per-client** (set_nonblocking on accepted fd, EPOLL_CTL_ADD,
  EPOLL_CTL_MOD): log and drop only that client; other clients unaffected.
- **EPOLL_CTL_DEL**: log on unexpected errno; tolerate ENOENT/EBADF,
  which can race with kernel cleanup.

set_nonblocking now returns bool so callers can act on failure.

## Verification
- SET/GET round-trip
- redis-benchmark -t set,get unchanged
- SIGTERM still produces clean "Shutdown complete"

Fixes #15.